### PR TITLE
Add basic support for history option in the alda server

### DIFF
--- a/src/alda/worker.clj
+++ b/src/alda/worker.clj
@@ -51,19 +51,20 @@
     (reset! current-status :parsing)
     (log/debug "Requiring alda.lisp...")
     (require '[alda.lisp :refer :all])
-    (let* [score (try
-                   (log/debug "Parsing input...")
-                   (parse-input code :events)
-                   (catch Throwable e
-                     {:error e}))
-           ;; if history was nil, make it empty string
-           history (or history "")
-           ;; Parse and remove events
-           history (dissoc (try
-                             (log/debug "Parsing input...")
-                             (parse-input history :map)
-                             (catch Throwable e
-                               {:error e})) :events)]
+    (let [score (try
+                  (log/debug "Parsing body...")
+                  (parse-input code :events)
+                  (catch Throwable e
+                    {:error e}))
+          ;; if history was nil, make it empty string
+          history (or history "")
+          ;; Parse and remove events
+          history (-> (try
+                        (log/debug "Parsing history...")
+                        (parse-input history :map)
+                        (catch Throwable e
+                          {:error e}))
+                      (dissoc :events))]
       (if-let [error (or (:error score) (:error history))]
         (do
           (log/error error error)

--- a/src/alda/worker.clj
+++ b/src/alda/worker.clj
@@ -3,7 +3,6 @@
             [alda.parser     :refer (parse-input)]
             [alda.parser-util :refer (parse-to-events-with-context)]
             [alda.lisp.score :refer (continue)]
-            [alda.lisp.model.records   :refer (->AbsoluteOffset)]
             [alda.sound      :as    sound :refer (*play-opts*)]
             [alda.sound.midi :as    midi]
             [alda.util       :as    util]
@@ -64,14 +63,7 @@
                         (parse-input history :map)
                         (catch Throwable e
                           {:error e}))
-                      (dissoc :events))
-          history (assoc history :instruments
-                         (reduce-kv (fn [m k v] (assoc m k
-                                                       (assoc v
-                                                              :current-offset (->AbsoluteOffset 0)
-                                                              :last-offset (->AbsoluteOffset 0))))
-                                    {}
-                                    (:instruments history)))]
+                      (dissoc :events))]
       (if-let [error (or (when (= :parse-failure context) score) (:error history))]
         (do
           (log/error error error)

--- a/src/alda/worker.clj
+++ b/src/alda/worker.clj
@@ -1,6 +1,7 @@
 (ns alda.worker
   (:require [alda.now        :as    now]
             [alda.parser     :refer (parse-input)]
+            [alda.lisp.score :refer (continue)]
             [alda.sound      :as    sound :refer (*play-opts*)]
             [alda.sound.midi :as    midi]
             [alda.util       :as    util]
@@ -45,27 +46,36 @@
 (def current-error (atom nil))
 
 (defn handle-code-play
-  [code]
+  [code history]
   (future
     (reset! current-status :parsing)
     (log/debug "Requiring alda.lisp...")
     (require '[alda.lisp :refer :all])
-    (let [score (try
-                  (log/debug "Parsing input...")
-                  (parse-input code :map)
-                  (catch Throwable e
-                    {:error e}))]
-      (if-let [error (:error score)]
+    (let* [score (try
+                   (log/debug "Parsing input...")
+                   (parse-input code :events)
+                   (catch Throwable e
+                     {:error e}))
+           ;; if history was nil, make it empty string
+           history (or history "")
+           ;; Parse and remove events
+           history (dissoc (try
+                             (log/debug "Parsing input...")
+                             (parse-input history :map)
+                             (catch Throwable e
+                               {:error e})) :events)]
+      (if-let [error (or (:error score) (:error history))]
         (do
           (log/error error error)
           (reset! current-status :error)
           (reset! current-error error))
         (try
-          (log/debug "Playing score...")
-          (reset! current-status :playing)
-          (now/play-score! score {:async? false :one-off? false})
-          (log/debug "Done playing score.")
-          (reset! current-status :available)
+          (let [score (continue history score)]
+            (log/debug "Playing score...")
+            (reset! current-status :playing)
+            (now/play-score! score {:async? false :one-off? false})
+            (log/debug "Done playing score.")
+            (reset! current-status :available))
           (catch Throwable e
             (log/error e e)
             (reset! current-status :error)
@@ -111,12 +121,13 @@
 
 (defmethod process "play"
   [{:keys [body options]}]
-  (let [{:keys [from to]} options]
+  (let [{:keys [from to history]} options]
     (binding [*play-opts* (assoc *play-opts*
                                  :from     from
                                  :to       to
+                                 :history  history
                                  :one-off? true)]
-      (handle-code-play body))))
+      (handle-code-play body history))))
 
 (defmethod process "play-status"
   [_]
@@ -239,4 +250,3 @@
                                      "BUSY"))
               (reset! last-heartbeat (System/currentTimeMillis))))))))
   (exit! 0))
-

--- a/src/alda/worker.clj
+++ b/src/alda/worker.clj
@@ -3,6 +3,7 @@
             [alda.parser     :refer (parse-input)]
             [alda.parser-util :refer (parse-to-events-with-context)]
             [alda.lisp.score :refer (continue)]
+            [alda.lisp.model.records   :refer (->AbsoluteOffset)]
             [alda.sound      :as    sound :refer (*play-opts*)]
             [alda.sound.midi :as    midi]
             [alda.util       :as    util]
@@ -63,7 +64,14 @@
                         (parse-input history :map)
                         (catch Throwable e
                           {:error e}))
-                      (dissoc :events))]
+                      (dissoc :events))
+          history (assoc history :instruments
+                         (reduce-kv (fn [m k v] (assoc m k
+                                                       (assoc v
+                                                              :current-offset (->AbsoluteOffset 0)
+                                                              :last-offset (->AbsoluteOffset 0))))
+                                    {}
+                                    (:instruments history)))]
       (if-let [error (or (when (= :parse-failure context) score) (:error history))]
         (do
           (log/error error error)


### PR DESCRIPTION
This is my first attempt to add support for a history flag (server side). (STILL IN DEVELOPMENT)

blocking alda-lang/alda-client-java#1

(I don't know clojure too well, so this might be terrible, let me know if it is :P)

Right now the following works:
`alda play --history '(tempo! 500)' --play 'piano: c d e'`

But this does not work:
`alda play --history 'piano: c d e f g' --play 'c d e'`

The error that I get is:
```
c d e
^
Expected one of:
"⚙"
#"[a-zA-Z]{2}[\w_]*"
```
which I'd assume means the syntax checking regexes need to be changed, which I'm not sure how to do (and I don't want to get wrong, since I don't know 100% of the alda syntax). I might take a stab at that tomorrow/later this week.

One of the thinigs I'm pretty worried about is error checking (I'm not sure if I got it right, could you take a look at that for me?).

Let me know if theres anything overall I can improve too! :smile: 