### PR TITLE
Support for stop-playback command

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -4,7 +4,7 @@
   '[
     ; dev
     [adzerk/bootlaces      "0.1.13" :scope "test"]
-    [alda/core             "0.2.0"  :scope "test"]
+    [alda/core             "0.2.2"  :scope "test"]
     [adzerk/boot-test      "1.2.0"  :scope "test"]
     [alda/sound-engine-clj "0.2.0"  :scope "test"]
 

--- a/build.boot
+++ b/build.boot
@@ -6,7 +6,7 @@
     [adzerk/bootlaces      "0.1.13" :scope "test"]
     [alda/core             "0.2.2"  :scope "test"]
     [adzerk/boot-test      "1.2.0"  :scope "test"]
-    [alda/sound-engine-clj "0.2.0"  :scope "test"]
+    [alda/sound-engine-clj "0.3.0"  :scope "test"]
 
     ; server / worker
     [com.taoensso/timbre    "4.10.0" :exclusions [org.clojure/clojure]]

--- a/src/alda/server.clj
+++ b/src/alda/server.clj
@@ -81,6 +81,8 @@
 
 (def shutting-down-response (successful-response "Shutting down..."))
 
+(def stopping-playback-response (successful-response "Stopping playback..."))
+
 (defn status-response
   [available total backend-port]
   (successful-response
@@ -199,6 +201,11 @@
       :else
       (log/debug "Supervisor approves of the current number of workers."))))
 
+(defn stop-playback!
+  [backend]
+  (doseq [{:keys [address]} (all-workers)]
+    (zmq/send-msg backend [address "STOP"])))
+
 (defn murder-workers!
   [backend shutting-down?]
   (doseq [{:keys [address]} (all-workers)]
@@ -295,6 +302,11 @@
                          (status-response (count @available-workers)
                                           workers
                                           backend-port))
+
+             "stop-playback"
+             (do
+               (respond-to msg frontend stopping-playback-response)
+               (stop-playback! backend))
 
              "stop-server"
              (do

--- a/src/alda/worker.clj
+++ b/src/alda/worker.clj
@@ -49,8 +49,8 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Keep information about each job in memory for 15 minutes.
-(def ^:const JOB_CACHE_TTL (* 15 60 1000))
+;; Keep information about each job in memory for 2 hours.
+(def ^:const JOB_CACHE_TTL (* 2 60 60 1000))
 
 (defrecord Job [status score error stop!])
 

--- a/src/alda/worker.clj
+++ b/src/alda/worker.clj
@@ -51,7 +51,7 @@
 
 (def ^:const JOB_CACHE_SIZE 20)
 
-(defrecord Job [status score error])
+(defrecord Job [status score error stop!])
 
 (def job-cache (atom (cache/fifo-cache-factory {} :threshold JOB_CACHE_SIZE)))
 
@@ -75,7 +75,7 @@
                      (if (cache/has? c id)
                        (-> (cache/hit c id)
                            (update id assoc :status status))
-                       (cache/miss c id (Job. status nil nil))))))
+                       (cache/miss c id (Job. status nil nil nil))))))
 
 (defn pending?
   [{:keys [status] :as job}]
@@ -89,7 +89,7 @@
   [code {:keys [history from to jobId]}]
   (try
     (log/debugf "Starting job %s..." jobId)
-    (update-job! jobId (Job. :parsing nil nil))
+    (update-job! jobId (Job. :parsing nil nil nil))
     (let [_       (log/debug "Parsing body...")
           events  (parse-input code :output :events-or-error)
           _       (log/debug "Parsing history...")
@@ -99,19 +99,29 @@
                        :to       to
                        :async?   true
                        :one-off? true}
-            {:keys [score wait]}
+            {:keys [score stop! wait]}
             (if (empty? history)
               (now/play-score! (score/score events) play-opts)
               (now/with-score* (atom history)
                 (now/play-with-opts! play-opts events)))]
-        (update-job! jobId (Job. :playing score nil))
+        (update-job! jobId (Job. :playing score nil stop!))
         (wait)
         (refresh-alda-environment!))
       (log/debug "Done playing score.")
       (update-job-status! jobId :success))
     (catch Throwable e
       (log/error e e)
-      (update-job! jobId (Job. :error nil e)))))
+      (update-job! jobId (Job. :error nil e nil)))))
+
+(defn stop-playback!
+  "Stops playback for all jobs where that is possible (i.e. ones that have a
+   `:stop!` function)."
+  []
+  (doseq [[id {:keys [stop!] :as job}] @job-cache
+          :when stop!]
+    (stop!)
+    (update-job! id (assoc job :status :success)))
+  (refresh-alda-environment!))
 
 (defn handle-code-play
   [code {:keys [jobId] :as options}]
@@ -161,6 +171,19 @@
   [{:keys [body options]}]
   (handle-code-play body options))
 
+(defn- sanitize-score-for-json
+  "We need to convert the score (a Clojure map) into a JSON string to send as a
+   response, but certain values in the map are not serializable as JSON."
+  [score]
+  (-> score
+      ;; remove scheduled function events
+      (update :events (fn [events]
+                        (remove #(instance? alda.lisp.model.records.Function %)
+                                events)))
+      ;; remove the audio-context (an atom containing information specific to
+      ;; playing the score)
+      (dissoc :audio-context)))
+
 (defmethod process "play-status"
   [{:keys [options]}]
   (let [job-id (get options :jobId)
@@ -177,16 +200,7 @@
 
           :else
           (-> (success-response (name status))
-              ;; HACK: Clojure functions are not serializable as JSON, so we're
-              ;; just leaving them out of the returned score for now
-              (assoc :score
-                     (-> score
-                         (update :events
-                                 #(remove (fn [event]
-                                            (instance?
-                                              alda.lisp.model.records.Function
-                                              event))
-                                          %))))
+              (assoc :score (sanitize-score-for-json score))
               (assoc :pending (pending? job))))
         (assoc :jobId job-id))))
 
@@ -239,6 +253,9 @@
                "KILL"      (do
                              (log/info "Received KILL signal from server.")
                              (reset! running? false))
+               "STOP"      (do
+                             (log/info "Received STOP signal from server.")
+                             (stop-playback!))
                "HEARTBEAT" (do
                              (log/debug "Got HEARTBEAT from server.")
                              (reset! lives MAX-LIVES))

--- a/src/alda/worker.clj
+++ b/src/alda/worker.clj
@@ -49,11 +49,12 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def ^:const JOB_CACHE_SIZE 20)
+;; Keep information about each job in memory for 15 minutes.
+(def ^:const JOB_CACHE_TTL (* 15 60 1000))
 
 (defrecord Job [status score error stop!])
 
-(def job-cache (atom (cache/fifo-cache-factory {} :threshold JOB_CACHE_SIZE)))
+(def job-cache (atom (cache/ttl-cache-factory {} :ttl JOB_CACHE_TTL)))
 
 (defn update-job! [id job]
   "Upserts a Job record into the cache.

--- a/src/alda/worker.clj
+++ b/src/alda/worker.clj
@@ -27,10 +27,6 @@
   (log/debug "Requiring alda.lisp...")
   (require '[alda.lisp :refer :all]))
 
-(defn refresh-alda-environment!
-  []
-  (midi/open-midi-synth!))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- success-response
@@ -99,15 +95,14 @@
       (let [play-opts {:from     from
                        :to       to
                        :async?   true
-                       :one-off? true}
+                       :one-off? false}
             {:keys [score stop! wait]}
             (if (empty? history)
               (now/play-score! (score/score events) play-opts)
               (now/with-score* (atom history)
                 (now/play-with-opts! play-opts events)))]
         (update-job! jobId (Job. :playing score nil stop!))
-        (wait)
-        (refresh-alda-environment!))
+        (wait))
       (log/debug "Done playing score.")
       (update-job-status! jobId :success))
     (catch Throwable e
@@ -121,8 +116,7 @@
   (doseq [[id {:keys [stop!] :as job}] @job-cache
           :when stop!]
     (stop!)
-    (update-job! id (assoc job :status :success)))
-  (refresh-alda-environment!))
+    (update-job! id (assoc job :status :success))))
 
 (defn handle-code-play
   [code {:keys [jobId] :as options}]

--- a/test/alda/worker_test.clj
+++ b/test/alda/worker_test.clj
@@ -97,5 +97,5 @@
                 {:keys [success body] :as res} (json/parse-string json true)]
             (is success)))))
     (testing "should accept signals from the server"
-      (doseq [signal ["HEARTBEAT" "KILL"]]
+      (doseq [signal ["HEARTBEAT" "STOP" "KILL"]]
         (zmq/send-msg *socket* signal)))))


### PR DESCRIPTION
The glue between the client running `alda stop` (or `:stop` in the Alda REPL), and the worker using the new "stop playback" feature implemented in https://github.com/alda-lang/alda-sound-engine-clj/pull/8.

When the server gets a `stop-playback` command, it sends a `STOP` message to all workers.

When a worker gets the `STOP` signal, it stops any currently playing scores.