### PR TITLE
Remove call to start JSyn SynthesisEngine

### DIFF
--- a/src/alda/worker.clj
+++ b/src/alda/worker.clj
@@ -23,6 +23,7 @@
 (defn start-alda-environment!
   []
   (midi/open-midi-synth!)
+  (midi/open-midi-sequencer!)
   (log/debug "Requiring alda.lisp...")
   (require '[alda.lisp :refer :all]))
 

--- a/src/alda/worker.clj
+++ b/src/alda/worker.clj
@@ -22,7 +22,6 @@
 
 (defn start-alda-environment!
   []
-  (sound/start-synthesis-engine!)
   (midi/open-midi-synth!)
   (log/debug "Requiring alda.lisp...")
   (require '[alda.lisp :refer :all]))


### PR DESCRIPTION
To be merged after https://github.com/alda-lang/alda-sound-engine-clj/pull/11, which will remove our dependency on JSyn and use Java MIDI Sequencers instead to do the scheduling. That PR will remove `sound/start-synthesis-engine!` which makes this project not compile. This PR fixes that.